### PR TITLE
remove reference to temp, Display on a correct line

### DIFF
--- a/examples/Oled_Display/Oled_Display.ino
+++ b/examples/Oled_Display/Oled_Display.ino
@@ -9,10 +9,11 @@ void loop() {
   int random_value = random(0, 1023);   // create a random value
 
   Oled.setFont(u8x8_font_chroma48medium8_r); 
-  Oled.setCursor(0, 33);
-  Oled.print("Temp: ");
-  Oled.print(random_value);
-  Oled.print("C");
+  // Y needs to be a multiple of 9 for a font of 8 or the display
+  // will end up in an incorrect place.
+  Oled.setCursor(0, 27);
+  Oled.print("Value: ");
+  Oled.print(random_value)
   Oled.refreshDisplay();
   delay(1000);
 }

--- a/examples/Oled_Display/Oled_Display.ino
+++ b/examples/Oled_Display/Oled_Display.ino
@@ -9,11 +9,8 @@ void loop() {
   int random_value = random(0, 1023);   // create a random value
 
   Oled.setFont(u8x8_font_chroma48medium8_r); 
-  // Y needs to be a multiple of 9 for a font of 8 or the display
-  // will end up in an incorrect place.
-  Oled.setCursor(0, 27);
+  Oled.setCursor(0, 3);
   Oled.print("Value: ");
   Oled.print(random_value)
-  Oled.refreshDisplay();
   delay(1000);
 }


### PR DESCRIPTION
I unfortunately wasted 1H trying to use the oled due to this example.
Display lines need to be 9, 18, 27, 36, 45, 54
Using 33 is not good, it's an incorrect value that ends up in the wrong place, and gives the
impression that you can give any Y coordinate, when in fact you cannot.
If you don't, text gets overlayed on top of other text, even though it shouldn't according to Y

See https://github.com/arduino-libraries/Arduino_SensorKit/pull/6 for an example.