### PR TITLE
Use GitHub Actions for continuous integration

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,0 +1,7 @@
+# See: https://github.com/codespell-project/codespell#using-a-config-file
+[codespell]
+# In the event of a false positive, add the problematic word, in all lowercase, to a comma-separated list here:
+ignore-words-list = ,
+check-filenames =
+check-hidden =
+skip = ./.git

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+# See: https://docs.github.com/en/github/administering-a-repository/configuration-options-for-dependency-updates#about-the-dependabotyml-file
+version: 2
+
+updates:
+  # Configure check for outdated GitHub Actions actions in workflows.
+  # See: https://docs.github.com/en/github/administering-a-repository/keeping-your-actions-up-to-date-with-dependabot
+  - package-ecosystem: github-actions
+    directory: / # Check the repository's workflows under /.github/workflows/
+    schedule:
+      interval: daily

--- a/.github/workflows/check-arduino.yml
+++ b/.github/workflows/check-arduino.yml
@@ -1,0 +1,28 @@
+name: Check Arduino
+
+# See: https://docs.github.com/en/free-pro-team@latest/actions/reference/events-that-trigger-workflows
+on:
+  push:
+  pull_request:
+  schedule:
+    # Run every Tuesday at 8 AM UTC to catch breakage caused by new rules added to Arduino Lint.
+    - cron: "0 8 * * TUE"
+  workflow_dispatch:
+  repository_dispatch:
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Arduino Lint
+        uses: arduino/arduino-lint-action@v1
+        with:
+          compliance: specification
+          library-manager: update
+          # Always use this setting for official repositories. Remove for 3rd party projects.
+          official: true
+          project-type: library

--- a/.github/workflows/compile-examples.yml
+++ b/.github/workflows/compile-examples.yml
@@ -23,6 +23,9 @@ jobs:
     name: ${{ matrix.board.fqbn }}
     runs-on: ubuntu-latest
 
+    env:
+      SKETCHES_REPORTS_PATH: sketches-reports
+
     strategy:
       fail-fast: false
 
@@ -63,3 +66,12 @@ jobs:
             - name: U8g2
           sketch-paths: |
             - examples
+          enable-deltas-report: true
+          sketches-report-path: ${{ env.SKETCHES_REPORTS_PATH }}
+
+      - name: Save sketches report as workflow artifact
+        uses: actions/upload-artifact@v2
+        with:
+          if-no-files-found: error
+          path: ${{ env.SKETCHES_REPORTS_PATH }}
+          name: ${{ env.SKETCHES_REPORTS_PATH }}

--- a/.github/workflows/compile-examples.yml
+++ b/.github/workflows/compile-examples.yml
@@ -1,0 +1,65 @@
+name: Compile Examples
+
+# See: https://docs.github.com/en/free-pro-team@latest/actions/reference/events-that-trigger-workflows
+on:
+  push:
+    paths:
+      - ".github/workflows/compile-examples.yml"
+      - "examples/**"
+      - "src/**"
+  pull_request:
+    paths:
+      - ".github/workflows/compile-examples.yml"
+      - "examples/**"
+      - "src/**"
+  schedule:
+    # Run every Tuesday at 8 AM UTC to catch breakage caused by changes to external resources (libraries, platforms).
+    - cron: "0 8 * * TUE"
+  workflow_dispatch:
+  repository_dispatch:
+
+jobs:
+  build:
+    name: ${{ matrix.board.fqbn }}
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+
+      matrix:
+        board:
+          - fqbn: arduino:avr:uno
+            platforms: |
+              - name: arduino:avr
+          - fqbn: arduino:avr:mega
+            platforms: |
+              - name: arduino:avr
+          - fqbn: arduino:avr:leonardo
+            platforms: |
+              - name: arduino:avr
+          - fqbn: arduino:megaavr:uno2018
+            platforms: |
+              - name: arduino:megaavr
+          - fqbn: arduino:samd:arduino_zero_edbg
+            platforms: |
+              - name: arduino:samd
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Compile examples
+        uses: arduino/compile-sketches@v1
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          fqbn: ${{ matrix.board.fqbn }}
+          platforms: ${{ matrix.board.platforms }}
+          libraries: |
+            # Install the library from the local path.
+            - source-path: ./
+            - name: DHT sensor library
+            - name: Grove-3-Axis-Digital-Accelerometer-2g-to-16g-LIS3DHTR
+            - name: Grove - Barometer Sensor BMP280
+            - name: U8g2
+          sketch-paths: |
+            - examples

--- a/.github/workflows/report-size-deltas.yml
+++ b/.github/workflows/report-size-deltas.yml
@@ -1,0 +1,24 @@
+name: Report Size Deltas
+
+# See: https://docs.github.com/en/free-pro-team@latest/actions/reference/events-that-trigger-workflows
+on:
+  push:
+    paths:
+      - ".github/workflows/report-size-deltas.yml"
+  schedule:
+    # Run at the minimum interval allowed by GitHub Actions.
+    # Note: GitHub Actions periodically has outages which result in workflow failures.
+    # In this event, the workflows will start passing again once the service recovers.
+    - cron: "*/5 * * * *"
+  workflow_dispatch:
+  repository_dispatch:
+
+jobs:
+  report:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Comment size deltas reports to PRs
+        uses: arduino/report-size-deltas@v1
+        with:
+          # The name of the workflow artifact created by the sketch compilation workflow
+          sketches-reports-source: sketches-reports

--- a/.github/workflows/spell-check.yml
+++ b/.github/workflows/spell-check.yml
@@ -1,0 +1,22 @@
+name: Spell Check
+
+# See: https://docs.github.com/en/free-pro-team@latest/actions/reference/events-that-trigger-workflows
+on:
+  push:
+  pull_request:
+  schedule:
+    # Run every Tuesday at 8 AM UTC to catch new misspelling detections resulting from dictionary updates.
+    - cron: "0 8 * * TUE"
+  workflow_dispatch:
+  repository_dispatch:
+
+jobs:
+  spellcheck:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Spell check
+        uses: codespell-project/actions-codespell@master

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Arduino Sensorkit Library
 
 [![Check Arduino status](https://github.com/arduino-libraries/Arduino_SensorKit/actions/workflows/check-arduino.yml/badge.svg)](https://github.com/arduino-libraries/Arduino_SensorKit/actions/workflows/check-arduino.yml)
+[![Compile Examples status](https://github.com/arduino-libraries/Arduino_SensorKit/actions/workflows/compile-examples.yml/badge.svg)](https://github.com/arduino-libraries/Arduino_SensorKit/actions/workflows/compile-examples.yml)
 [![Spell Check status](https://github.com/arduino-libraries/Arduino_SensorKit/actions/workflows/spell-check.yml/badge.svg)](https://github.com/arduino-libraries/Arduino_SensorKit/actions/workflows/spell-check.yml)
 
 This documentation contains information about the classes and the usage of Arduino_SensorKit library which is primarily used in the [Arduino Sensor Kit](https://store.arduino.cc/sensor-kit-base). This library is a wrapper for other libraries such as

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Arduino Sensorkit Library
 
+[![Spell Check status](https://github.com/arduino-libraries/Arduino_SensorKit/actions/workflows/spell-check.yml/badge.svg)](https://github.com/arduino-libraries/Arduino_SensorKit/actions/workflows/spell-check.yml)
+
 This documentation contains information about the classes and the usage of Arduino_SensorKit library which is primarily used in the [Arduino Sensor Kit](https://store.arduino.cc/sensor-kit-base). This library is a wrapper for other libraries such as
 
 * [u8g2](https://github.com/olikraus/U8g2_Arduino) Library for monochrome displayes

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # Arduino Sensorkit Library
 
+[![Check Arduino status](https://github.com/arduino-libraries/Arduino_SensorKit/actions/workflows/check-arduino.yml/badge.svg)](https://github.com/arduino-libraries/Arduino_SensorKit/actions/workflows/check-arduino.yml)
 [![Spell Check status](https://github.com/arduino-libraries/Arduino_SensorKit/actions/workflows/spell-check.yml/badge.svg)](https://github.com/arduino-libraries/Arduino_SensorKit/actions/workflows/spell-check.yml)
 
 This documentation contains information about the classes and the usage of Arduino_SensorKit library which is primarily used in the [Arduino Sensor Kit](https://store.arduino.cc/sensor-kit-base). This library is a wrapper for other libraries such as

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Arduino Sensorkit Library
+# Arduino SensorKit Library
 
 [![Check Arduino status](https://github.com/arduino-libraries/Arduino_SensorKit/actions/workflows/check-arduino.yml/badge.svg)](https://github.com/arduino-libraries/Arduino_SensorKit/actions/workflows/check-arduino.yml)
 [![Compile Examples status](https://github.com/arduino-libraries/Arduino_SensorKit/actions/workflows/compile-examples.yml/badge.svg)](https://github.com/arduino-libraries/Arduino_SensorKit/actions/workflows/compile-examples.yml)
@@ -6,9 +6,9 @@
 
 This documentation contains information about the classes and the usage of Arduino_SensorKit library which is primarily used in the [Arduino Sensor Kit](https://store.arduino.cc/sensor-kit-base). This library is a wrapper for other libraries such as
 
-* [u8g2](https://github.com/olikraus/U8g2_Arduino) Library for monochrome displayes
+* [u8g2](https://github.com/olikraus/U8g2_Arduino) Library for monochrome displays
 * [Seeed_Arduino_LIS3DHTR](https://github.com/Seeed-Studio/Seeed_Arduino_LIS3DHTR) for the 3 Axis Accelerometer
 * [Grove_BMP280](https://github.com/Seeed-Studio/Grove_BMP280) Library for the Barometer
 * [DHT-sensor-library](https://github.com/adafruit/DHT-sensor-library) for the Temperature and Humidity Sensor
 
-The Arduino_SensorKit Library can be downloaded from the Arduino IDE’s library manager or from the github repository
+The Arduino_SensorKit Library can be downloaded from the Arduino IDE's library manager or from the GitHub repository.

--- a/docs/readme.md
+++ b/docs/readme.md
@@ -1,12 +1,12 @@
 # **Sensor Kit Reference**
 
 This documentation contains information about the classes and the usage of **Arduino_SensorKit** library which is primarily used in the [Arduino Sensor Kit](https://sensorkit.arduino.cc/). This library is a wrapper for other libraries such as 
-* [u8g2 Library for monochrome displayes](https://github.com/olikraus/u8g2)
+* [u8g2 Library for monochrome displays](https://github.com/olikraus/u8g2)
 * [Seeed_Arduino_LIS3DHTR for the 3 Axis Accelerometer](https://github.com/Seeed-Studio/Seeed_Arduino_LIS3DHTR)
 * [Grove_BMP280 Library for the Barometer](https://github.com/Seeed-Studio/Grove_BMP280)
 * [DHT-sensor-library for the Temperature and Humidity Sensor](https://github.com/adafruit/DHT-sensor-library)
 
-The Arduino_SensorKit Library can be downloaded from the Arduino IDE’s library manager or from the [github repository](https://github.com/arduino-libraries/Arduino_SensorKit)
+The Arduino_SensorKit Library can be downloaded from the Arduino IDE's Library Manager or from the [GitHub repository](https://github.com/arduino-libraries/Arduino_SensorKit)
 
 # Classes
 
@@ -22,7 +22,7 @@ The Arduino_SensorKit Library can be downloaded from the Arduino IDE’s library
 ##  OLED
 Using the Grove - OLED Display 0.96 inch
 
-### Initialising the driver
+### Initializing the driver
 
 Init the display driver
 
@@ -59,7 +59,7 @@ void loop() {
 ## Accelerometer
 Using the Grove - 3-Axis Digital Accelerometer (±1.5g)
 
-### Initialising the sensor
+### Initializing the sensor
 
 Initialize the sensor
 
@@ -137,7 +137,7 @@ Return if the sensor its good to give the data
 Using the Grove Barometer Sensor (BMP280)
 The Pressure sensor can get temperature, pressure and altitude
 
-### Initialising the sensor
+### Initializing the sensor
 Initialize the sensor
 ```cpp
    void setup(){
@@ -212,7 +212,7 @@ By default, once you include the library it has been set to digital pin `3`, it 
 #define DHTPIN yourPin
 ```
     
-### Initialising the sensor
+### Initializing the sensor
 ```cpp
   void setup(){
     Environment.begin();

--- a/examples/Combined_Demo/Combined_Demo.ino
+++ b/examples/Combined_Demo/Combined_Demo.ino
@@ -1,6 +1,6 @@
 // Combined Demo by Marc MERLIN <marc_soft@merlins.org>
 // Reviewed by Pablo Marquínez  <p.marquinez@arduino.cc>
-// This demo use all the devices from the Arduino SensorKit
+// This demo uses all the devices from the Arduino Sensor Kit
 // Showing the values on the Display
 
 #include "Arduino_SensorKit.h"

--- a/examples/Pressure_Sensor/Pressure_Sensor.ino
+++ b/examples/Pressure_Sensor/Pressure_Sensor.ino
@@ -9,7 +9,7 @@ void loop() {
   // Get and print temperatures
   Serial.print("Temp: ");
   Serial.print(Pressure.readTemperature());
-  Serial.println("C"); // The unit for  Celsius because        original arduino don't support speical symbols
+  Serial.println("C"); // The unit for Celsius because original Arduino don't support special symbols
 
   // Get and print atmospheric pressure data
   Serial.print("Pressure: ");

--- a/keywords.txt
+++ b/keywords.txt
@@ -1,5 +1,5 @@
 #######################################
-# Syntax Coloring Map of SensorKit
+# Syntax Coloring Map of Arduino_SensorKit
 #######################################
 
 #######################################

--- a/src/Arduino_SensorKit.h
+++ b/src/Arduino_SensorKit.h
@@ -14,7 +14,7 @@
 #include "Arduino_SensorKit_BMP280.h"   // Pressure
 #include "Arduino_SensorKit_LIS3DHTR.h" // Accel
 #include "DHT.h"                        // Temp & Humidity
-#include "U8x8lib.h"                    // Oled Display
+#include "U8x8lib.h"                    // OLED Display
 
 //Defines
 #ifndef DHTTYPE


### PR DESCRIPTION
This PR provides the standardized [GitHub Actions](https://github.com/features/actions)-based CI configuration for Arduino libraries.

### Dependabot

Dependabot will periodically check the versions of all actions used in the repository's workflows. If any are found to be outdated, it will submit a pull request to update them.

NOTE: Dependabot's PRs will sometimes try to pin to the patch version of the action (e.g., updating `uses: foo/bar@v1` to `uses: foo/bar@v2.3.4`). When the action author has [provided a major version ref](https://docs.github.com/en/actions/creating-actions/about-actions#using-release-management-for-actions), use that instead (e.g., `uses: foo/bar@v2`). Once the major version has been updated in the workflow, Dependabot should not submit an update PR again until the next major version bump. So even if the PRs from Dependabot are not always exactly correct, their value lies in bringing the maintainer's attention to the fact that the action version in use is outdated. Dependabot will automatically close its PR once the workflow has been updated.

More information:
https://docs.github.com/en/github/administering-a-repository/keeping-your-actions-up-to-date-with-dependabot

### Spell check

On every push, pull request, and periodically, use [the `codespell-project/actions-codespell` action](https://github.com/codespell-project/actions-codespell) to check for commonly misspelled words.

In the event of a false positive, the problematic word should be added, in all lowercase, to the `ignore-words-list` field of `./.codespellrc`. Regardless of the case of the word in the false positive, it must be in all lowercase in the ignore list. The ignore list is comma-separated with no spaces.

### Arduino Lint

On every push, pull request, and periodically, run [Arduino Lint](https://github.com/arduino/arduino-lint) to check for common problems not related to the project code.

### Compile examples

On every push or pull request that affects library source or example files, and periodically, use [the `arduino/compile-sketches` action](https://github.com/arduino/compile-sketches) to compile all example sketches for the specified boards.

### Report size deltas

On creation or commit to a pull request, use [the `arduino/report-size-deltas` action](https://github.com/arduino/report-size-deltas) to comment a report of the resulting change in memory usage of the examples to the PR thread.

---
Fixes https://github.com/arduino-libraries/Arduino_SensorKit/issues/17