### PR TITLE
Switched back to SW I2C Display

### DIFF
--- a/src/Arduino_SensorKit.cpp
+++ b/src/Arduino_SensorKit.cpp
@@ -1,7 +1,7 @@
 #include "Arduino_SensorKit.h"
 
 //Declare component's classes
-U8X8_SSD1306_128X64_NONAME_HW_I2C Oled(/* reset=*/ U8X8_PIN_NONE);
+U8X8_SSD1306_128X64_NONAME_SW_I2C Oled(/* clock=*/ SCL, /* data=*/ SDA, /* reset=*/ U8X8_PIN_NONE);
 DHT Environment(DHTPIN, DHTTYPE);
 SensorKit_LIS3DHTR Accelerometer;
 SensorKit_BMP280 Pressure;

--- a/src/Arduino_SensorKit.h
+++ b/src/Arduino_SensorKit.h
@@ -25,7 +25,7 @@
 #endif
 
 //Make the declared components from the .cpp to the sketch available
-extern U8X8_SSD1306_128X64_NONAME_HW_I2C Oled;
+extern U8X8_SSD1306_128X64_NONAME_SW_I2C Oled;
 extern SensorKit_LIS3DHTR Accelerometer;
 extern SensorKit_BMP280 Pressure;
 extern DHT Environment;


### PR DESCRIPTION
* Display switched back to `U8X8_SSD1306_128X64_NONAME_SW_I2C` (SW i2c) to fix an issue of the Display that doesn't work when it's connected without anymore I2C modules.