### PR TITLE
Fix CI Build

### DIFF
--- a/.github/workflows/compile-examples.yml
+++ b/.github/workflows/compile-examples.yml
@@ -34,9 +34,6 @@ jobs:
           - fqbn: arduino:avr:uno
             platforms: |
               - name: arduino:avr
-          - fqbn: arduino:avr:mega
-            platforms: |
-              - name: arduino:avr
           - fqbn: arduino:avr:leonardo
             platforms: |
               - name: arduino:avr

--- a/.github/workflows/compile-examples.yml
+++ b/.github/workflows/compile-examples.yml
@@ -43,9 +43,6 @@ jobs:
           - fqbn: arduino:megaavr:uno2018
             platforms: |
               - name: arduino:megaavr
-          - fqbn: arduino:samd:arduino_zero_edbg
-            platforms: |
-              - name: arduino:samd
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
The Arduino Sensor Kit is explicitly targetting the Arduino Uno. Therefore we do not need a CI build for the Arduino Zero (although it would fit on the sensor kit shield when only considering the form factor).