### PR TITLE
Update DHT library dependency

### DIFF
--- a/.github/workflows/compile-examples.yml
+++ b/.github/workflows/compile-examples.yml
@@ -54,7 +54,7 @@ jobs:
           libraries: |
             # Install the library from the local path.
             - source-path: ./
-            - name: DHT sensor library
+            - name: Grove Temperature And Humidity Sensor
             - name: Grove-3-Axis-Digital-Accelerometer-2g-to-16g-LIS3DHTR
             - name: Grove - Barometer Sensor BMP280
             - name: U8g2

--- a/examples/Temp_and_Humidity/Temp_and_Humidity.ino
+++ b/examples/Temp_and_Humidity/Temp_and_Humidity.ino
@@ -1,7 +1,12 @@
 //#define DHTPIN 3 // By default its connected to pin D3, it can be changed, define it before the #include of the library
 #include "Arduino_SensorKit.h"
 
+//uncomment line below if using DHT20
+//#define Environment Environment_I2C
+
 void setup() {
+  //uncomment line below if using DHT20
+  //Wire.begin();
   Serial.begin(9600);
   Environment.begin();
 }

--- a/library.properties
+++ b/library.properties
@@ -8,4 +8,4 @@ category=Sensors
 url=https://sensorkit.arduino.cc/
 architectures=avr
 precompiled=false
-depends=DHT sensor library,Grove - Barometer Sensor BMP280,U8g2,Grove-3-Axis-Digital-Accelerometer-2g-to-16g-LIS3DHTR
+depends=Grove Temperature And Humidity Sensor,Grove - Barometer Sensor BMP280,U8g2,Grove-3-Axis-Digital-Accelerometer-2g-to-16g-LIS3DHTR

--- a/src/Arduino_SensorKit.cpp
+++ b/src/Arduino_SensorKit.cpp
@@ -2,6 +2,7 @@
 
 //Declare component's classes
 U8X8_SSD1306_128X64_NONAME_SW_I2C Oled(/* clock=*/ SCL, /* data=*/ SDA, /* reset=*/ U8X8_PIN_NONE);
-DHT Environment(DHTPIN, DHTTYPE);
+DHT Environment(DHTPIN,DHT11);
+DHT Environment_I2C(DHT20);
 SensorKit_LIS3DHTR Accelerometer;
 SensorKit_BMP280 Pressure;

--- a/src/Arduino_SensorKit.h
+++ b/src/Arduino_SensorKit.h
@@ -16,10 +16,6 @@
 #include "DHT.h"                        // Temp & Humidity
 #include "U8x8lib.h"                    // OLED Display
 
-//Defines
-#ifndef DHTTYPE
-  #define DHTTYPE DHT11
-#endif
 #ifndef DHTPIN
   #define DHTPIN 3
 #endif
@@ -29,4 +25,5 @@ extern U8X8_SSD1306_128X64_NONAME_SW_I2C Oled;
 extern SensorKit_LIS3DHTR Accelerometer;
 extern SensorKit_BMP280 Pressure;
 extern DHT Environment;
+extern DHT Environment_I2C;
 #endif


### PR DESCRIPTION
Change the library for DHT sensor + add a wrapper class specifically for I2C connection (DHT20).

New library is the [Grove Temperature and Humidity Sensor](https://github.com/Seeed-Studio/Grove_Temperature_And_Humidity_Sensor) library which allows you to connect using a one-wire protocol (DHT11) and using I2C (DHT20).